### PR TITLE
bruno/api

### DIFF
--- a/Backend/Routes/userRoute.js
+++ b/Backend/Routes/userRoute.js
@@ -12,7 +12,6 @@ router.post("/ask-doubt", authenticate, askDoubt);
 router.post("/try-assign-teacher", tryAssignTeacher);
 
 
-
 router.post("/signup",signup)
 router.post("/login",login)
 router.post("/logout", logout); 

--- a/Backend/capstone_test/Log-out.bru
+++ b/Backend/capstone_test/Log-out.bru
@@ -1,0 +1,11 @@
+meta {
+  name: Log-out
+  type: http
+  seq: 4
+}
+
+post {
+  url: http://localhost:8080/logout
+  body: none
+  auth: inherit
+}

--- a/Backend/capstone_test/Login.bru
+++ b/Backend/capstone_test/Login.bru
@@ -1,0 +1,11 @@
+meta {
+  name: Login
+  type: http
+  seq: 3
+}
+
+post {
+  url: http://localhost:8080/login
+  body: none
+  auth: inherit
+}

--- a/Backend/capstone_test/SIGN-UP.bru
+++ b/Backend/capstone_test/SIGN-UP.bru
@@ -1,0 +1,11 @@
+meta {
+  name: SIGN-UP
+  type: http
+  seq: 2
+}
+
+post {
+  url: https://localhost:8080
+  body: none
+  auth: inherit
+}

--- a/Backend/capstone_test/ask-doubt.bru
+++ b/Backend/capstone_test/ask-doubt.bru
@@ -1,0 +1,11 @@
+meta {
+  name: ask-doubt
+  type: http
+  seq: 7
+}
+
+post {
+  url: http://localhost:8080/ask-doubt
+  body: none
+  auth: inherit
+}

--- a/Backend/capstone_test/bruno.json
+++ b/Backend/capstone_test/bruno.json
@@ -1,0 +1,9 @@
+{
+  "version": "1",
+  "name": "capstone_test",
+  "type": "collection",
+  "ignore": [
+    "node_modules",
+    ".git"
+  ]
+}

--- a/Backend/capstone_test/get-user-by-id.bru
+++ b/Backend/capstone_test/get-user-by-id.bru
@@ -1,0 +1,11 @@
+meta {
+  name: get-user-by-id
+  type: http
+  seq: 6
+}
+
+get {
+  url: http://localhost:8080/user/6877ec767d3f6fb8f54433e7
+  body: none
+  auth: inherit
+}

--- a/Backend/capstone_test/show-users.bru
+++ b/Backend/capstone_test/show-users.bru
@@ -1,0 +1,11 @@
+meta {
+  name: show-users
+  type: http
+  seq: 5
+}
+
+get {
+  url: http://localhost:8080/showuser
+  body: none
+  auth: inherit
+}


### PR DESCRIPTION
### **User description**
/review


___

### **PR Type**
Tests


___

### **Description**
- Add Bruno API testing collection for backend endpoints

- Create test files for authentication and user operations

- Minor code formatting cleanup in user routes


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Backend Routes"] --> B["Bruno Test Collection"]
  B --> C["Authentication Tests"]
  B --> D["User Management Tests"]
  C --> E["Login/Logout/Signup"]
  D --> F["Get User/Show Users/Ask Doubt"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Formatting</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>userRoute.js</strong><dd><code>Minor formatting cleanup in user routes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Backend/Routes/userRoute.js

- Remove extra blank line for code formatting


</details>


  </td>
  <td><a href="https://github.com/kalviumcommunity/S65_ANKIT_CAPSTONE_DOUBTSYNC/pull/18/files#diff-29632ba09eb11857c5a9abfcc66f6ef16b4719a062b72a34d870c6671419836f">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>bruno.json</strong><dd><code>Bruno collection configuration setup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Backend/capstone_test/bruno.json

<ul><li>Create Bruno collection configuration file<br> <li> Set collection name as "capstone_test"<br> <li> Configure ignore patterns for node_modules and .git</ul>


</details>


  </td>
  <td><a href="https://github.com/kalviumcommunity/S65_ANKIT_CAPSTONE_DOUBTSYNC/pull/18/files#diff-58b224f758befe8fad9da062f99d5016796391a2628b896f094b5dd01fd9e54d">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SIGN-UP.bru</strong><dd><code>Signup endpoint test configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Backend/capstone_test/SIGN-UP.bru

<ul><li>Add Bruno test file for signup endpoint<br> <li> Configure POST request to localhost:8080</ul>


</details>


  </td>
  <td><a href="https://github.com/kalviumcommunity/S65_ANKIT_CAPSTONE_DOUBTSYNC/pull/18/files#diff-c25ee4187e3657c95b70a3b071e48469715337ccad953d2cc4709e73e17c92ca">+11/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Login.bru</strong><dd><code>Login endpoint test configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Backend/capstone_test/Login.bru

<ul><li>Add Bruno test file for login endpoint<br> <li> Configure POST request to localhost:8080/login</ul>


</details>


  </td>
  <td><a href="https://github.com/kalviumcommunity/S65_ANKIT_CAPSTONE_DOUBTSYNC/pull/18/files#diff-15c49dae1ae679262c1c6062da4e3f9b709766cbafc58c1825bd4044ae5e4f6e">+11/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Log-out.bru</strong><dd><code>Logout endpoint test configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Backend/capstone_test/Log-out.bru

<ul><li>Add Bruno test file for logout endpoint<br> <li> Configure POST request to localhost:8080/logout</ul>


</details>


  </td>
  <td><a href="https://github.com/kalviumcommunity/S65_ANKIT_CAPSTONE_DOUBTSYNC/pull/18/files#diff-c25f41f7c70610fddf905bc72b079a436a8baf5374ce8851b34e1759df91f7ba">+11/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>show-users.bru</strong><dd><code>Show users endpoint test configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Backend/capstone_test/show-users.bru

<ul><li>Add Bruno test file for show users endpoint<br> <li> Configure GET request to localhost:8080/showuser</ul>


</details>


  </td>
  <td><a href="https://github.com/kalviumcommunity/S65_ANKIT_CAPSTONE_DOUBTSYNC/pull/18/files#diff-4984ddf215f475588ba64e01e06afe41aefbfd707a8c7266becba4fa3fd2b33b">+11/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>get-user-by-id.bru</strong><dd><code>Get user by ID test configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Backend/capstone_test/get-user-by-id.bru

<ul><li>Add Bruno test file for get user by ID endpoint<br> <li> Configure GET request with specific user ID parameter</ul>


</details>


  </td>
  <td><a href="https://github.com/kalviumcommunity/S65_ANKIT_CAPSTONE_DOUBTSYNC/pull/18/files#diff-43e4b2b3f935783b46f42fdcbe0f7b1918fbcc33d1d968418576a2476797d25e">+11/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ask-doubt.bru</strong><dd><code>Ask doubt endpoint test configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Backend/capstone_test/ask-doubt.bru

<ul><li>Add Bruno test file for ask doubt endpoint<br> <li> Configure POST request to localhost:8080/ask-doubt</ul>


</details>


  </td>
  <td><a href="https://github.com/kalviumcommunity/S65_ANKIT_CAPSTONE_DOUBTSYNC/pull/18/files#diff-44788be442b94125da3906550638f982479c2c0aa8e31de344bf1458f2a611ae">+11/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

